### PR TITLE
Add a preview/demo mode to WfdBot

### DIFF
--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -1,0 +1,251 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Generate a preview of a single updated/created wfd item."""
+# Based on PreviewTable by Alicia Fagerving
+from __future__ import unicode_literals
+from builtins import dict
+
+import pywikibot
+
+import wikidataStuff.helpers as helpers
+from wikidataStuff.WikidataStuff import WikidataStuff as WdS
+# @todo: Generalise and move to WikidataStuff
+# @todo: If ref gets tied to a Statement then ref handling gets significantly
+#        simplified and must no longer be one for all.
+
+
+class PreviewItem(object):
+    """Base bot to enrich Wikidata with info from WFD."""
+
+    def __init__(self, labels, descriptions, protoclaims, item, ref):
+        """
+        Initialise the PreviewItem.
+
+        :param labels: dict holding the label/aliases per language
+        :param descriptions: dict holding the descriptions per language
+        :param protoclaims: dict of Statements per Property
+        :param item: the item to which the data should be added
+            (None for a new item)
+        :param ref: the ref which is attached to every single item
+        """
+        self.labels_dict = labels
+        self.desc_dict = descriptions
+        self.item = item
+        self.protoclaims = protoclaims
+        self.ref = ref
+
+    def make_preview_page(self):
+        txt = ''
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Labels'),
+            data=self.format_labels())
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Descriptions'),
+            data=self.format_descriptions())
+        txt += '{key}: {data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Matching item'),
+            data=self.format_item())
+        # remove this next one if multiple references
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Reference (same for all claims)'),
+            data=PreviewItem.format_reference(self.ref))
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Claims'),
+            data=self.make_preview_table())
+        return txt
+
+    def make_preview_table(self):
+        table_head = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            #  "! References \n"  # re-add if multiple references
+        )
+        table_end = '|}'
+        table_row = (
+            '|-\n'
+            '| {prop} \n'
+            '| {value} \n'
+            '| {quals} \n'
+            # '| {references} \n'  # re-add if multiple references
+        )
+
+        # start table construction
+        table = table_head
+        for prop, statements in self.protoclaims.items():
+            if not statements:
+                continue
+            prop = PreviewItem.make_wikidata_template(prop)
+            for statement in helpers.listify(statements):
+                quals = ''
+                if statement.quals:
+                    if len(statement.quals) > 1:
+                        quals = ['* {}'.format(PreviewItem.format_qual(qual))
+                                 for qual in statement.quals]
+                    else:
+                        quals = [PreviewItem.format_qual(statement.quals[0])]
+
+                table += table_row.format(
+                    prop=prop,
+                    value=PreviewItem.format_itis(statement),
+                    quals='\n'.join(quals),
+                    references=''  # self.ref  # re-add if multiple references
+                )
+
+        table += table_end
+        return table
+
+    @staticmethod
+    def format_qual(qual):
+        """Create a preview for a single Qualifier."""
+        prop = PreviewItem.make_wikidata_template(qual.prop)
+        itis = PreviewItem.format_itis(qual.itis)
+        return '{0}: {1}'.format(prop, itis)
+
+    @staticmethod
+    def format_reference(ref):
+        """Create a preview for a single Reference."""
+        txt = ''
+        if ref.source_test:
+            txt += ':{}:\n'.format(PreviewItem.make_text_italics('tested'))
+            for claim in ref.source_test:
+                txt += ':*{}\n'.format(PreviewItem.format_claim(claim))
+        if ref.source_notest:
+            txt += ':{}:\n'.format(PreviewItem.make_text_italics('not tested'))
+            for claim in ref.source_notest:
+                txt += ':*{}\n'.format(PreviewItem.format_claim(claim))
+
+        return txt
+
+    @staticmethod
+    def format_claim(claim):
+        """Create a preview for a single pywikibot.Claim."""
+        special = False
+        itis = claim.getTarget()
+        if claim.getSnakType() != 'value':
+            special = True
+            itis = claim.getSnakType()
+
+        return '{prop}: {itis}'.format(
+            prop=PreviewItem.make_wikidata_template(claim.id),
+            itis=PreviewItem.format_itis(itis, special)
+        )
+
+    @staticmethod
+    def format_itis(itis, special=False):
+        """
+        Create a preview for the itis component of a Statement.
+
+        :param itis: a Statement or the itis component of a Statement or
+            Qualifier.
+        :param special: if it is a special type of value (i.e. novalue,
+            somevalue). Is set automatically if a Statement is passed to itis.
+        """
+        # handle the case where a Statement was passed
+        if isinstance(itis, WdS.Statement):
+            special = itis.special
+            itis = itis.itis
+
+        if isinstance(itis, pywikibot.ItemPage):
+            return PreviewItem.make_wikidata_template(itis)
+        elif special:
+            PreviewItem.make_wikidata_template(itis, special=True)
+        elif isinstance(itis, pywikibot.WbQuantity):
+            unit = itis.get_unit_item() or ''
+            amount = itis.amount
+            if unit:
+                unit = PreviewItem.make_wikidata_template(unit)
+            return '{} {}'.format(amount, unit).strip()
+        elif isinstance(itis, pywikibot.WbTime):
+            return itis.toTimestr()
+        else:
+            return str(itis)
+
+    def format_labels(self):
+        """
+        Create a label(s) preview.
+
+        The first label is italicised (to indicate it is the preferred label
+        whereas the rest are aliases).
+
+        :return: string
+        """
+        preview = ''
+        for lang, labels in self.labels_dict.items():
+            if labels:
+                labels = [PreviewItem.make_text_italics(labels[0])] + \
+                    labels[1:]
+                preview += '* {}: {}\n'.format(
+                    PreviewItem.make_text_bold(lang), '|'.join(labels))
+        return preview
+
+    def format_descriptions(self):
+        """
+        Create a descriptions(s) preview.
+
+        :return: string
+        """
+        preview = ''
+        for lang, description in self.desc_dict.items():
+            preview += '* {}: {}\n'.format(
+                PreviewItem.make_text_bold(lang), description)
+        return preview
+
+    def format_item(self):
+        """
+        Create an item preview.
+
+        :return: string
+        """
+        if self.item:
+            return PreviewItem.make_wikidata_template(self.item)
+        else:
+            return 'New item created'
+
+    @staticmethod
+    def make_text_bold(text):
+        """Wikitext format the text as bold."""
+        return "'''{}'''".format(text)
+
+    @staticmethod
+    def make_text_italics(text):
+        """Wikitext format the text as italics."""
+        return "''{}''".format(text)
+
+    @staticmethod
+    def make_wikidata_template(wd_entry, special=False):
+        """
+        Make a wikidata template for items and properties.
+
+        :param item: a Q/P prefixed item/property id or a ItemPage/PropertyPage
+        :param special: if it is a special type of value
+            (i.e. novalue, somevalue)
+        :return: string
+        """
+        if isinstance(wd_entry, (pywikibot.ItemPage, pywikibot.PropertyPage)):
+            wd_id = wd_entry.id
+        else:
+            wd_id = wd_entry
+
+        typ = None
+        if wd_id.startswith('Q') or wd_id.startswith('P'):
+            typ = wd_id[0]
+        elif special:
+            typ = "Q'"
+            # convert to format used by the template
+            if wd_id == 'somevalue':
+                wd_id = 'some value'
+            elif wd_id == 'novalue':
+                wd_id = 'no value'
+            else:
+                raise ValueError(
+                    'Sorry but "{}" is not a recognized special '
+                    'value/snacktype.'.format(wd_id))
+        else:
+            raise ValueError(
+                'Sorry only items and properties are supported, not whatever '
+                '"{}" is.'.format(wd_id))
+
+        return '{{%s|%s}}' % (typ, wd_id)

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -37,7 +37,7 @@ class PreviewItem(object):
         """Create a preview of the entire PreviewItem."""
         txt = ''
         txt += '{key}:\n{data}\n\n'.format(
-            key=PreviewItem.make_text_bold('Labels'),
+            key=PreviewItem.make_text_bold('Labels|Aliases'),
             data=self.format_labels())
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Descriptions'),

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -3,7 +3,6 @@
 """Generate a preview of a single updated/created wfd item."""
 # Based on PreviewTable by Alicia Fagerving
 from __future__ import unicode_literals
-from builtins import dict
 
 import pywikibot
 
@@ -35,6 +34,7 @@ class PreviewItem(object):
         self.ref = ref
 
     def make_preview_page(self):
+        """Create a preview of the entire PreviewItem."""
         txt = ''
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Labels'),
@@ -51,10 +51,11 @@ class PreviewItem(object):
             data=PreviewItem.format_reference(self.ref))
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Claims'),
-            data=self.make_preview_table())
+            data=self.format_protoclaims())
         return txt
 
-    def make_preview_table(self):
+    def format_protoclaims(self):
+        """Create a preview table for the protoclaims."""
         table_head = (
             "{| class='wikitable'\n"
             "|-\n"

--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -18,18 +18,22 @@ from __future__ import unicode_literals
 import pywikibot
 
 import wikidataStuff.helpers as helpers
-import wikidataStuff.wdqsLookup as wdqsLookup
+import wikidataStuff.WdqToWdqs as WdqToWdqs
 from wikidataStuff.WikidataStuff import WikidataStuff as WdS
 
 from WFD.WFDBase import WfdBot
+from WFD.PreviewItem import PreviewItem
 
 parameter_help = """\
 RBDbot options (may be omitted):
+-year              Year to which the WFD data applies.
 -new               if present new items are created on Wikidata, otherwise
                    only updates are processed.
 -in_file           path to the data file
 -mappings          path to the mappings file (if not "mappings.json")
 -cutoff            number items to process before stopping (if not then all)
+-preview_file      path to a file where previews should be outputted, sets the
+                   run to demo mode
 
 Can also handle any pywikibot options. Most importantly:
 -simulate          don't write to database
@@ -43,9 +47,11 @@ EDIT_SUMMARY = 'importing #RBD using data from #WFD'
 class RbdBot(WfdBot):
     """Bot to enrich/create info on Wikidata for RBD objects."""
 
-    def __init__(self, mappings, year, new=False, cutoff=None):
+    def __init__(self, mappings, year, new=False, cutoff=None,
+                 preview_file=None):
         """Initialise the RbdBot."""
-        super(RbdBot, self).__init__(mappings, year, new, cutoff, EDIT_SUMMARY)
+        super(RbdBot, self).__init__(mappings, year, new, cutoff,
+                                     EDIT_SUMMARY, preview_file=preview_file)
 
         self.rbd_q = 'Q132017'
         self.eu_rbd_p = 'P2965'
@@ -59,7 +65,7 @@ class RbdBot(WfdBot):
 
     def load_existing_rbd(self):
         """Load existing RBD items and check all have unique ids."""
-        item_ids = wdqsLookup.make_claim_wdqs_search(
+        item_ids = WdqToWdqs.make_claim_wdqs_search(
             'P31', q_value=self.rbd_q, optional_props=[self.eu_rbd_p, ])
 
         # invert and check existence and uniqueness
@@ -132,25 +138,40 @@ class RbdBot(WfdBot):
             item = None
             if rbd_code in self.rbd_id_items.keys():
                 item = self.wd.QtoItemPage(self.rbd_id_items[rbd_code])
-            elif self.new:
-                item = self.create_new_rbd_item(entry_data)
-            else:
-                # skip non existant if not self.new
-                continue
-            item.exists()
 
-            labels = self.make_labels(entry_data, with_alias=True)
-            descriptions = self.make_descriptions(entry_data)
-            protoclaims = self.make_protoclaims(
-                entry_data, self.countries.get(country).get('qId'))
+            if item or self.new:
+                self.process_single_rbd(entry_data, item, country)
+                count += 1
+
+    def process_single_rbd(self, data, item, country):
+        """
+        Process a rbd (whether item exists or not).
+
+        :param data: dict of data for a single rbd
+        :param item: Wikidata item associated with a rbd, or None if one
+            should be created.
+        :param country: the country code as a string
+        """
+        if not self.demo:
+            item = item or self.create_new_rbd_item(data, country)
+            item.exists()  # load the item contents
+
+        # Determine claims
+        labels = self.make_labels(data, with_alias=True)
+        descriptions = self.make_descriptions(data)
+        protoclaims = self.make_protoclaims(
+            data, self.countries.get(country).get('qId'))
+
+        # Upload claims
+        if self.demo:
+            self.preview_data.append(
+                PreviewItem(labels, descriptions, protoclaims, item, self.ref))
+        else:
             self.commit_labels(labels, item)
             self.commit_descriptions(descriptions, item)
             self.commit_claims(protoclaims, item)
 
-            # increment counter
-            count += 1
-
-    def create_new_rbd_item(self, entry_data):
+    def create_new_rbd_item(self, entry_data, country):
         """
         Create a new rbd item with some basic info and return it.
 
@@ -274,6 +295,7 @@ class RbdBot(WfdBot):
         in_file = None
         new = False
         cutoff = None
+        preview_file = None
         year = '2016'
 
         # Load pywikibot args and handle local args
@@ -290,6 +312,8 @@ class RbdBot(WfdBot):
                 year = value
             elif option == '-cutoff':
                 cutoff = int(value)
+            elif option == '-preview_file':
+                preview_file = value
 
         # require in_file
         if not in_file:
@@ -298,10 +322,14 @@ class RbdBot(WfdBot):
         # load mappings and initialise RBD object
         mappings = helpers.load_json_file(mappings, force_path)
         data = WfdBot.load_data(in_file, key='RBDSUCA')
-        rbd = RbdBot(mappings, year, new=new, cutoff=cutoff)
+        rbd = RbdBot(mappings, year, new=new, cutoff=cutoff,
+                     preview_file=preview_file)
         rbd.set_common_values(data)
 
         rbd.process_all_rbd(data)
+
+        if rbd.demo:
+            rbd.output_previews()
 
 
 if __name__ == "__main__":

--- a/WFD/WFDBase.py
+++ b/WFD/WFDBase.py
@@ -95,7 +95,6 @@ class WfdBot(object):
         self.language = None
         self.descriptions = None
 
-    # @todo: implement in RBD (partially done but should remove old uses)
     def set_common_values(self, data):
         """
         Set and validate values shared by every instance of the batch.

--- a/WFD/WFDBase.py
+++ b/WFD/WFDBase.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Base class on which to build WFD import bots."""
 from __future__ import unicode_literals
-from builtins import dict
+from builtins import dict, open
 import requests
 import xmltodict
 import datetime
@@ -54,7 +54,8 @@ class UnexpectedValueError(pywikibot.Error):
 class WfdBot(object):
     """Base bot to enrich Wikidata with info from WFD."""
 
-    def __init__(self, mappings, year, new, cutoff, edit_summary):
+    def __init__(self, mappings, year, new, cutoff, edit_summary,
+                 preview_file=None):
         """
         Initialise the WfdBot.
 
@@ -65,6 +66,8 @@ class WfdBot(object):
             being interpreted as all.
         :param edit_summary: string to append to all automatically generated
             edit summaries
+        :param preview_file: run in demo mode (create previews rather than
+            live edits) and output the result to this file.
         """
         self.repo = pywikibot.Site().data_repository()
         self.wd = WdS(self.repo, edit_summary)
@@ -72,6 +75,12 @@ class WfdBot(object):
         self.cutoff = cutoff
         self.mappings = mappings
         self.year = year
+        self.preview_file = preview_file
+        if preview_file:
+            self.demo = True
+        else:
+            self.demo = False
+        self.preview_data = []
 
         # known (lower case) non-names
         self.bad_names = ('not applicable', )
@@ -252,6 +261,14 @@ class WfdBot(object):
             return self.wd.make_new_item(item_data, summary)
         except pywikibot.data.api.APIError as e:
             raise pywikibot.Error('Error during item creation: {:s}'.format(e))
+
+    def output_previews(self):
+        """Output any PreviewItems to the preview_file."""
+        with open(self.preview_file, 'w', encoding='utf-8') as f:
+            for preview in self.preview_data:
+                f.write(preview.make_preview_page())
+                f.write('--------------\n\n')
+        pywikibot.output('Created "{}" for previews'.format(self.preview_file))
 
     @staticmethod
     def load_xml_url_data(url, key=None):

--- a/WFD/mappings.json
+++ b/WFD/mappings.json
@@ -57,7 +57,9 @@
         "NUTR": "Q12203192",
         "ORGA": "Q28854984",
         "SALI": "Q2002254",
-        "TEMP": "Q2914309"
+        "TEMP": "Q2914309",
+        "NOTA": "novalue",
+        "OTHE": "somevalue"
     },
     "swEcologicalStatusOrPotentialValue": {
         "@meta": "https://www.wikidata.org/wiki/User:AndreCostaWMSE-bot/WFD/swEcologicalStatusOrPotentialValue",

--- a/WFD/swb_import.py
+++ b/WFD/swb_import.py
@@ -80,7 +80,7 @@ class SwbBot(WfdBot):
         """
         Set and validate values shared by every SWB in the dataset.
 
-        :param data: dict of all the SWB:s in the RBD
+        :param data: SWB component of thexml data
         """
         super(SwbBot, self).set_common_values(data)
         try:
@@ -99,8 +99,9 @@ class SwbBot(WfdBot):
 
         Only increments counter when an swb is updated.
 
-        :param data: dict of all the swb:s in the RBD
+        :param data: list of all the swb:s in the RBD
         """
+        data = helpers.listify(data)
         count = 0
         for entry_data in data:
             if self.cutoff and count >= self.cutoff:
@@ -279,6 +280,7 @@ class SwbBot(WfdBot):
     # @todo: unify arg_handling by breaking this out into
     #        options = WfdBot.handle_args(args) which returns a dict.
     #        also move parameter_help.
+    #        separate mappings_file and actual mappings
     @staticmethod
     def main(*args):
         """Command line entry point."""


### PR DESCRIPTION
Adds the `-preview_file` argument which, if provided, outputs a
preview of the changes to that file rather than making the actual
changes. Can be run together with the `-simulate` argument for
paranoid users.

Also:
* Fix broken import in RBD
* Fix `novalue`/`somevalue` handling in impact type
* Fix single value in impact type
* Fix minor bugs/typos

@todo:
* Add tests for `PreviewItem`
* Handle/tasks for any @todos
* Rebase on master after #9 (and #10) have been merged

Task: [T166673](https://phabricator.wikimedia.org/T166673)