### PR TITLE
Preview

### DIFF
--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -1,0 +1,251 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Generate a preview of a single updated/created wfd item."""
+# Based on PreviewTable by Alicia Fagerving
+from __future__ import unicode_literals
+from builtins import dict
+
+import pywikibot
+
+import wikidataStuff.helpers as helpers
+from wikidataStuff.WikidataStuff import WikidataStuff as WdS
+# @todo: Generalise and move to WikidataStuff
+# @todo: If ref gets tied to a Statement then ref handling gets significantly
+#        simplified and must no longer be one for all.
+
+
+class PreviewItem(object):
+    """Base bot to enrich Wikidata with info from WFD."""
+
+    def __init__(self, labels, descriptions, protoclaims, item, ref):
+        """
+        Initialise the PreviewItem.
+
+        :param labels: dict holding the label/aliases per language
+        :param descriptions: dict holding the descriptions per language
+        :param protoclaims: dict of Statements per Property
+        :param item: the item to which the data should be added
+            (None for a new item)
+        :param ref: the ref which is attached to every single item
+        """
+        self.labels_dict = labels
+        self.desc_dict = descriptions
+        self.item = item
+        self.protoclaims = protoclaims
+        self.ref = ref
+
+    def make_preview_page(self):
+        txt = ''
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Labels'),
+            data=self.format_labels())
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Descriptions'),
+            data=self.format_descriptions())
+        txt += '{key}: {data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Matching item'),
+            data=self.format_item())
+        # remove this next one if multiple references
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Reference (same for all claims)'),
+            data=PreviewItem.format_reference(self.ref))
+        txt += '{key}:\n{data}\n\n'.format(
+            key=PreviewItem.make_text_bold('Claims'),
+            data=self.make_preview_table())
+        return txt
+
+    def make_preview_table(self):
+        table_head = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            #  "! References \n"  # re-add if multiple references
+        )
+        table_end = '|}'
+        table_row = (
+            '|-\n'
+            '| {prop} \n'
+            '| {value} \n'
+            '| {quals} \n'
+            # '| {references} \n'  # re-add if multiple references
+        )
+
+        # start table construction
+        table = table_head
+        for prop, statements in self.protoclaims.items():
+            if not statements:
+                continue
+            prop = PreviewItem.make_wikidata_template(prop)
+            for statement in helpers.listify(statements):
+                quals = ''
+                if statement.quals:
+                    if len(statement.quals) > 1:
+                        quals = ['* {}'.format(PreviewItem.format_qual(qual))
+                                 for qual in statement.quals]
+                    else:
+                        quals = [PreviewItem.format_qual(statement.quals[0])]
+
+                table += table_row.format(
+                    prop=prop,
+                    value=PreviewItem.format_itis(statement),
+                    quals='\n'.join(quals),
+                    references=''  # self.ref  # re-add if multiple references
+                )
+
+        table += table_end
+        return table
+
+    @staticmethod
+    def format_qual(qual):
+        """Create a preview for a single Qualifier."""
+        prop = PreviewItem.make_wikidata_template(qual.prop)
+        itis = PreviewItem.format_itis(qual.itis)
+        return '{0}: {1}'.format(prop, itis)
+
+    @staticmethod
+    def format_reference(ref):
+        """Create a preview for a single Reference."""
+        txt = ''
+        if ref.source_test:
+            txt += ':{}:\n'.format(PreviewItem.make_text_italics('tested'))
+            for claim in ref.source_test:
+                txt += ':*{}\n'.format(PreviewItem.format_claim(claim))
+        if ref.source_notest:
+            txt += ':{}:\n'.format(PreviewItem.make_text_italics('not tested'))
+            for claim in ref.source_notest:
+                txt += ':*{}\n'.format(PreviewItem.format_claim(claim))
+
+        return txt
+
+    @staticmethod
+    def format_claim(claim):
+        """Create a preview for a single pywikibot.Claim."""
+        special = False
+        itis = claim.getTarget()
+        if claim.getSnakType() != 'value':
+            special = True
+            itis = claim.getSnakType()
+
+        return '{prop}: {itis}'.format(
+            prop=PreviewItem.make_wikidata_template(claim.id),
+            itis=PreviewItem.format_itis(itis, special)
+        )
+
+    @staticmethod
+    def format_itis(itis, special=False):
+        """
+        Create a preview for the itis component of a Statement.
+
+        :param itis: a Statement or the itis component of a Statement or
+            Qualifier.
+        :param special: if it is a special type of value (i.e. novalue,
+            somevalue). Is set automatically if a Statement is passed to itis.
+        """
+        # handle the case where a Statement was passed
+        if isinstance(itis, WdS.Statement):
+            special = itis.special
+            itis = itis.itis
+
+        if isinstance(itis, pywikibot.ItemPage):
+            return PreviewItem.make_wikidata_template(itis)
+        elif special:
+            PreviewItem.make_wikidata_template(itis, special=True)
+        elif isinstance(itis, pywikibot.WbQuantity):
+            unit = itis.get_unit_item() or ''
+            amount = itis.amount
+            if unit:
+                unit = PreviewItem.make_wikidata_template(unit)
+            return '{} {}'.format(amount, unit).strip()
+        elif isinstance(itis, pywikibot.WbTime):
+            return itis.toTimestr()
+        else:
+            return str(itis)
+
+    def format_labels(self):
+        """
+        Create a label(s) preview.
+
+        The first label is italicised (to indicate it is the preferred label
+        whereas the rest are aliases).
+
+        :return: string
+        """
+        preview = ''
+        for lang, labels in self.labels_dict.items():
+            if labels:
+                labels = [PreviewItem.make_text_italics(labels[0])] + \
+                    labels[1:]
+                preview += '* {}: {}\n'.format(
+                    PreviewItem.make_text_bold(lang), '|'.join(labels))
+        return preview
+
+    def format_descriptions(self):
+        """
+        Create a descriptions(s) preview.
+
+        :return: string
+        """
+        preview = ''
+        for lang, description in self.desc_dict.items():
+            preview += '* {}: {}\n'.format(
+                PreviewItem.make_text_bold(lang), description)
+        return preview
+
+    def format_item(self):
+        """
+        Create an item preview.
+
+        :return: string
+        """
+        if self.item:
+            return PreviewItem.make_wikidata_template(self.item)
+        else:
+            return 'New item created'
+
+    @staticmethod
+    def make_text_bold(text):
+        """Wikitext format the text as bold."""
+        return "'''{}'''".format(text)
+
+    @staticmethod
+    def make_text_italics(text):
+        """Wikitext format the text as italics."""
+        return "''{}''".format(text)
+
+    @staticmethod
+    def make_wikidata_template(wd_entry, special=False):
+        """
+        Make a wikidata template for items and properties.
+
+        :param item: a Q/P prefixed item/property id or a ItemPage/PropertyPage
+        :param special: if it is a special type of value
+            (i.e. novalue, somevalue)
+        :return: string
+        """
+        if isinstance(wd_entry, (pywikibot.ItemPage, pywikibot.PropertyPage)):
+            wd_id = wd_entry.id
+        else:
+            wd_id = wd_entry
+
+        typ = None
+        if wd_id.startswith('Q') or wd_id.startswith('P'):
+            typ = wd_id[0]
+        elif special:
+            typ = "Q'"
+            # convert to format used by the template
+            if wd_id == 'somevalue':
+                wd_id = 'some value'
+            elif wd_id == 'novalue':
+                wd_id = 'no value'
+            else:
+                raise ValueError(
+                    'Sorry but "{}" is not a recognized special '
+                    'value/snacktype.'.format(wd_id))
+        else:
+            raise ValueError(
+                'Sorry only items and properties are supported, not whatever '
+                '"{}" is.'.format(wd_id))
+
+        return '{{%s|%s}}' % (typ, wd_id)

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -37,7 +37,7 @@ class PreviewItem(object):
         """Create a preview of the entire PreviewItem."""
         txt = ''
         txt += '{key}:\n{data}\n\n'.format(
-            key=PreviewItem.make_text_bold('Labels|Aliases'),
+            key=PreviewItem.make_text_bold('Labels | Aliases'),
             data=self.format_labels())
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Descriptions'),
@@ -179,7 +179,7 @@ class PreviewItem(object):
                 labels = [PreviewItem.make_text_italics(labels[0])] + \
                     labels[1:]
                 preview += '* {}: {}\n'.format(
-                    PreviewItem.make_text_bold(lang), '|'.join(labels))
+                    PreviewItem.make_text_bold(lang), ' | '.join(labels))
         return preview
 
     def format_descriptions(self):

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -94,7 +94,7 @@ class PreviewItem(object):
                 table += table_row.format(
                     prop=prop,
                     value=PreviewItem.format_itis(statement),
-                    quals='\n'.join(quals),
+                    quals=' \n'.join(quals),
                     references=''  # self.ref  # re-add if multiple references
                 )
 
@@ -155,7 +155,7 @@ class PreviewItem(object):
         if isinstance(itis, pywikibot.ItemPage):
             return PreviewItem.make_wikidata_template(itis)
         elif special:
-            PreviewItem.make_wikidata_template(itis, special=True)
+            return PreviewItem.make_wikidata_template(itis, special=True)
         elif isinstance(itis, pywikibot.WbQuantity):
             unit = itis.get_unit_item() or ''
             amount = itis.amount
@@ -234,7 +234,8 @@ class PreviewItem(object):
             wd_id = wd_entry
 
         typ = None
-        if wd_id.startswith('Q') or wd_id.startswith('P'):
+        if helpers.is_str(wd_id) and (
+                wd_id.startswith('Q') or wd_id.startswith('P')):
             typ = wd_id[0]
         elif special:
             typ = "Q'"

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -4,6 +4,8 @@
 # Based on PreviewTable by Alicia Fagerving
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+
 import pywikibot
 
 import wikidataStuff.helpers as helpers
@@ -27,10 +29,14 @@ class PreviewItem(object):
             (None for a new item)
         :param ref: a Reference which is attached to every single item
         """
-        self.labels_dict = labels
-        self.desc_dict = descriptions
+        # sort dicts by key to ensure consistent behaviour
+        self.labels_dict = OrderedDict(
+            sorted(labels.items(), key=lambda t: t[0]))
+        self.desc_dict = OrderedDict(
+            sorted(descriptions.items(), key=lambda t: t[0]))
         self.item = item
-        self.protoclaims = protoclaims
+        self.protoclaims = OrderedDict(
+            sorted(protoclaims.items(), key=lambda t: t[0]))
         self.ref = ref
 
     def make_preview_page(self):

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -24,7 +24,7 @@ class PreviewItem(object):
 
         :param labels: dict holding the label/aliases per language code
         :param descriptions: dict holding the descriptions per language code
-        :param protoclaims: dict of Statements per property-id
+        :param protoclaims: dict of Statements per (P-prefixed) property-id
         :param item: the pywikibot.ItemPage to which the data should be added
             (None for a new item)
         :param ref: a Reference which is attached to every single item
@@ -35,8 +35,11 @@ class PreviewItem(object):
         self.desc_dict = OrderedDict(
             sorted(descriptions.items(), key=lambda t: t[0]))
         self.item = item
+
+        # sort by the numeric part of the property id
         self.protoclaims = OrderedDict(
-            sorted(protoclaims.items(), key=lambda t: t[0]))
+            sorted(protoclaims.items(), key=lambda t: int(t[0][1:])))
+
         self.ref = ref
 
     def make_preview_page(self):

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-"""Generate a preview of a single updated/created wfd item."""
+"""Generate a preview of a single updated/created WFD item."""
 # Based on PreviewTable by Alicia Fagerving
 from __future__ import unicode_literals
 
@@ -14,7 +14,7 @@ from wikidataStuff.WikidataStuff import WikidataStuff as WdS
 
 
 class PreviewItem(object):
-    """Base bot to enrich Wikidata with info from WFD."""
+    """A visualization of a single created/updated WFD item."""
 
     def __init__(self, labels, descriptions, protoclaims, item, ref=None):
         """
@@ -223,7 +223,8 @@ class PreviewItem(object):
         """
         Make a wikidata template for items and properties.
 
-        :param item: a Q/P prefixed item/property id or a ItemPage/PropertyPage
+        :param wd_entry: a Q/P prefixed item/property id or an
+            ItemPage/PropertyPage
         :param special: if it is a special type of value
             (i.e. novalue, somevalue)
         :return: string
@@ -247,7 +248,7 @@ class PreviewItem(object):
             else:
                 raise ValueError(
                     'Sorry but "{}" is not a recognized special '
-                    'value/snacktype.'.format(wd_id))
+                    'value/snaktype.'.format(wd_id))
         else:
             raise ValueError(
                 'Sorry only items and properties are supported, not whatever '

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -8,24 +8,24 @@ import pywikibot
 
 import wikidataStuff.helpers as helpers
 from wikidataStuff.WikidataStuff import WikidataStuff as WdS
-# @todo: Generalise and move to WikidataStuff
-# @todo: If ref gets tied to a Statement then ref handling gets significantly
-#        simplified and must no longer be one for all.
+# @todo: T167661 Generalise and move to WikidataStuff
+# @todo: T161116 If ref gets tied to a Statement then ref handling gets
+#        significantly simplified and must no longer be one for all.
 
 
 class PreviewItem(object):
     """Base bot to enrich Wikidata with info from WFD."""
 
-    def __init__(self, labels, descriptions, protoclaims, item, ref):
+    def __init__(self, labels, descriptions, protoclaims, item, ref=None):
         """
         Initialise the PreviewItem.
 
-        :param labels: dict holding the label/aliases per language
-        :param descriptions: dict holding the descriptions per language
-        :param protoclaims: dict of Statements per Property
-        :param item: the item to which the data should be added
+        :param labels: dict holding the label/aliases per language code
+        :param descriptions: dict holding the descriptions per language code
+        :param protoclaims: dict of Statements per property-id
+        :param item: the pywikibot.ItemPage to which the data should be added
             (None for a new item)
-        :param ref: the ref which is attached to every single item
+        :param ref: a Reference which is attached to every single item
         """
         self.labels_dict = labels
         self.desc_dict = descriptions
@@ -46,14 +46,17 @@ class PreviewItem(object):
             key=PreviewItem.make_text_bold('Matching item'),
             data=self.format_item())
         # remove this next one if multiple references
-        txt += '{key}:\n{data}\n\n'.format(
-            key=PreviewItem.make_text_bold('Reference (same for all claims)'),
-            data=PreviewItem.format_reference(self.ref))
+        if self.ref:
+            txt += '{key}:\n{data}\n\n'.format(
+                key=PreviewItem.make_text_bold(
+                    'Reference (same for all claims)'),
+                data=PreviewItem.format_reference(self.ref))
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Claims'),
             data=self.format_protoclaims())
         return txt
 
+    # @todo: T167663
     def format_protoclaims(self):
         """Create a preview table for the protoclaims."""
         table_head = (

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -37,7 +37,7 @@ class PreviewItem(object):
         """Create a preview of the entire PreviewItem."""
         txt = ''
         txt += '{key}:\n{data}\n\n'.format(
-            key=PreviewItem.make_text_bold('Labels'),
+            key=PreviewItem.make_text_bold('Labels|Aliases'),
             data=self.format_labels())
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Descriptions'),

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -167,6 +167,7 @@ class PreviewItem(object):
         else:
             return str(itis)
 
+    # @todo: T167791
     def format_labels(self):
         """
         Create a label(s) preview.
@@ -206,7 +207,7 @@ class PreviewItem(object):
         if self.item:
             return PreviewItem.make_wikidata_template(self.item)
         else:
-            return 'New item created'
+            return '–'  # New item created
 
     @staticmethod
     def make_text_bold(text):

--- a/WFD/PreviewItem.py
+++ b/WFD/PreviewItem.py
@@ -3,7 +3,6 @@
 """Generate a preview of a single updated/created wfd item."""
 # Based on PreviewTable by Alicia Fagerving
 from __future__ import unicode_literals
-from builtins import dict
 
 import pywikibot
 
@@ -35,6 +34,7 @@ class PreviewItem(object):
         self.ref = ref
 
     def make_preview_page(self):
+        """Create a preview of the entire PreviewItem."""
         txt = ''
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Labels'),
@@ -51,10 +51,11 @@ class PreviewItem(object):
             data=PreviewItem.format_reference(self.ref))
         txt += '{key}:\n{data}\n\n'.format(
             key=PreviewItem.make_text_bold('Claims'),
-            data=self.make_preview_table())
+            data=self.format_protoclaims())
         return txt
 
-    def make_preview_table(self):
+    def format_protoclaims(self):
+        """Create a preview table for the protoclaims."""
         table_head = (
             "{| class='wikitable'\n"
             "|-\n"

--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -18,18 +18,22 @@ from __future__ import unicode_literals
 import pywikibot
 
 import wikidataStuff.helpers as helpers
-import wikidataStuff.wdqsLookup as wdqsLookup
+import wikidataStuff.WdqToWdqs as WdqToWdqs
 from wikidataStuff.WikidataStuff import WikidataStuff as WdS
 
 from WFD.WFDBase import WfdBot
+from WFD.PreviewItem import PreviewItem
 
 parameter_help = """\
 RBDbot options (may be omitted):
+-year              Year to which the WFD data applies.
 -new               if present new items are created on Wikidata, otherwise
                    only updates are processed.
 -in_file           path to the data file
 -mappings          path to the mappings file (if not "mappings.json")
 -cutoff            number items to process before stopping (if not then all)
+-preview_file      path to a file where previews should be outputted, sets the
+                   run to demo mode
 
 Can also handle any pywikibot options. Most importantly:
 -simulate          don't write to database
@@ -43,9 +47,11 @@ EDIT_SUMMARY = 'importing #RBD using data from #WFD'
 class RbdBot(WfdBot):
     """Bot to enrich/create info on Wikidata for RBD objects."""
 
-    def __init__(self, mappings, year, new=False, cutoff=None):
+    def __init__(self, mappings, year, new=False, cutoff=None,
+                 preview_file=None):
         """Initialise the RbdBot."""
-        super(RbdBot, self).__init__(mappings, year, new, cutoff, EDIT_SUMMARY)
+        super(RbdBot, self).__init__(mappings, year, new, cutoff,
+                                     EDIT_SUMMARY, preview_file=preview_file)
 
         self.rbd_q = 'Q132017'
         self.eu_rbd_p = 'P2965'
@@ -59,7 +65,7 @@ class RbdBot(WfdBot):
 
     def load_existing_rbd(self):
         """Load existing RBD items and check all have unique ids."""
-        item_ids = wdqsLookup.make_claim_wdqs_search(
+        item_ids = WdqToWdqs.make_claim_wdqs_search(
             'P31', q_value=self.rbd_q, optional_props=[self.eu_rbd_p, ])
 
         # invert and check existence and uniqueness
@@ -132,25 +138,40 @@ class RbdBot(WfdBot):
             item = None
             if rbd_code in self.rbd_id_items.keys():
                 item = self.wd.QtoItemPage(self.rbd_id_items[rbd_code])
-            elif self.new:
-                item = self.create_new_rbd_item(entry_data)
-            else:
-                # skip non existant if not self.new
-                continue
-            item.exists()
 
-            labels = self.make_labels(entry_data, with_alias=True)
-            descriptions = self.make_descriptions(entry_data)
-            protoclaims = self.make_protoclaims(
-                entry_data, self.countries.get(country).get('qId'))
+            if item or self.new:
+                self.process_single_rbd(entry_data, item, country)
+                count += 1
+
+    def process_single_rbd(self, data, item, country):
+        """
+        Process a rbd (whether item exists or not).
+
+        :param data: dict of data for a single rbd
+        :param item: Wikidata item associated with a rbd, or None if one
+            should be created.
+        :param country: the country code as a string
+        """
+        if not self.demo:
+            item = item or self.create_new_rbd_item(data, country)
+            item.exists()  # load the item contents
+
+        # Determine claims
+        labels = self.make_labels(data, with_alias=True)
+        descriptions = self.make_descriptions(data)
+        protoclaims = self.make_protoclaims(
+            data, self.countries.get(country).get('qId'))
+
+        # Upload claims
+        if self.demo:
+            self.preview_data.append(
+                PreviewItem(labels, descriptions, protoclaims, item, self.ref))
+        else:
             self.commit_labels(labels, item)
             self.commit_descriptions(descriptions, item)
             self.commit_claims(protoclaims, item)
 
-            # increment counter
-            count += 1
-
-    def create_new_rbd_item(self, entry_data):
+    def create_new_rbd_item(self, entry_data, country):
         """
         Create a new rbd item with some basic info and return it.
 
@@ -274,6 +295,7 @@ class RbdBot(WfdBot):
         in_file = None
         new = False
         cutoff = None
+        preview_file = None
         year = '2016'
 
         # Load pywikibot args and handle local args
@@ -290,6 +312,8 @@ class RbdBot(WfdBot):
                 year = value
             elif option == '-cutoff':
                 cutoff = int(value)
+            elif option == '-preview_file':
+                preview_file = value
 
         # require in_file
         if not in_file:
@@ -298,10 +322,14 @@ class RbdBot(WfdBot):
         # load mappings and initialise RBD object
         mappings = helpers.load_json_file(mappings, force_path)
         data = WfdBot.load_data(in_file, key='RBDSUCA')
-        rbd = RbdBot(mappings, year, new=new, cutoff=cutoff)
+        rbd = RbdBot(mappings, year, new=new, cutoff=cutoff,
+                     preview_file=preview_file)
         rbd.set_common_values(data)
 
         rbd.process_all_rbd(data)
+
+        if rbd.demo:
+            rbd.output_previews()
 
 
 if __name__ == "__main__":

--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -92,7 +92,7 @@ class RbdBot(WfdBot):
 
         :param data: RBDSUCA component of the xml data
         """
-        data = helpers.listify(data.get('RBD'))  # list of rbds in the country
+        data = helpers.listify(data.get('RBD'))  # list of RBDs in the country
         found_ca = []
         for d in data:
             found_ca.append(d['primeCompetentAuthority'])
@@ -104,7 +104,7 @@ class RbdBot(WfdBot):
         """
         Handle every single RBD in a datafile (within one country).
 
-        :param data: list of all the rbds in the country
+        :param data: list of all the RBDs in the country or a single RBD.
         """
         data = helpers.listify(data)
         count = 0
@@ -123,10 +123,10 @@ class RbdBot(WfdBot):
     # @todo: T167662
     def process_single_rbd(self, data, item):
         """
-        Process a rbd (whether item exists or not).
+        Process an RBD (whether item exists or not).
 
-        :param data: dict of data for a single rbd
-        :param item: Wikidata item associated with a rbd, or None if one
+        :param data: dict of data for a single RBD
+        :param item: Wikidata item associated with an RBD, or None if one
             should be created.
         """
         if not self.demo:
@@ -149,9 +149,9 @@ class RbdBot(WfdBot):
 
     def create_new_rbd_item(self, entry_data):
         """
-        Create a new rbd item with some basic info and return it.
+        Create a new RBD item with some basic info and return it.
 
-        :param entry_data: dict of data for a single rbd
+        :param entry_data: dict of data for a single RBD
         :return: pywikibot.ItemPage
         """
         labels = self.make_labels(entry_data)
@@ -174,7 +174,7 @@ class RbdBot(WfdBot):
         @todo Figure out how to handle internationalRBDName (which can be in
               other languages, or a duplicate, or different English).
 
-        :param entry_data: dict with the data for the rbd
+        :param entry_data: dict with the data for the RBD
         :param with_alias: add RBDcode to list of names
         """
         labels = {}
@@ -191,7 +191,7 @@ class RbdBot(WfdBot):
     def make_descriptions(self, entry_data):
         """Make a description object from the available info.
 
-        :param entry_data: dict with the data for the rbd
+        :param entry_data: dict with the data for the RBD
         :return: dict
         """
         description_type = self.descriptions.get('national')
@@ -217,7 +217,7 @@ class RbdBot(WfdBot):
             "subUnitsDefined": "No"
         }
 
-        :param entry_data: dict with the data for the rbd per above
+        :param entry_data: dict with the data for the RBD per above
         """
         protoclaims = {}
         #   P31: self.rbd_q
@@ -233,7 +233,7 @@ class RbdBot(WfdBot):
             self.wd.QtoItemPage(
                 self.competent_authorities[
                     entry_data['primeCompetentAuthority']]))
-        #   P2046: rbdArea + self.area_unit (can I set unknown accuracy)
+        #   P2046: rbdArea + self.area_unit
         protoclaims['P2046'] = WdS.Statement(
             pywikibot.WbQuantity(entry_data['rbdArea'],
                                  unit=self.area_unit, site=self.wd.repo))

--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -120,6 +120,7 @@ class RbdBot(WfdBot):
                 self.process_single_rbd(entry_data, item)
                 count += 1
 
+    # @todo: T167662
     def process_single_rbd(self, data, item):
         """
         Process a rbd (whether item exists or not).
@@ -251,6 +252,7 @@ class RbdBot(WfdBot):
         # check if CA in self.competent_authorities else raise error
         self.check_all_competent_authorities(data)
 
+    # @todo: T167658
     @staticmethod
     def main(*args):
         """Command line entry point."""

--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -70,7 +70,7 @@ class RbdBot(WfdBot):
 
         # invert and check existence and uniqueness
         rbd_id_items = {}
-        for q_id, values in item_ids.iteritems():
+        for q_id, values in item_ids.items():
             eu_rbd_code = values.get(self.eu_rbd_p)
             if not eu_rbd_code:
                 raise pywikibot.Error(

--- a/WFD/WFDBase.py
+++ b/WFD/WFDBase.py
@@ -95,7 +95,6 @@ class WfdBot(object):
         self.language = None
         self.descriptions = None
 
-    # @todo: implement in RBD (partially done but should remove old uses)
     def set_common_values(self, data):
         """
         Set and validate values shared by every instance of the batch.

--- a/WFD/WFDBase.py
+++ b/WFD/WFDBase.py
@@ -333,7 +333,7 @@ class WfdBot(object):
                 value = '[{}]'.format(', '.join(sorted(diff)))
                 raise UnmappedValueError(label, value)
 
-    # @todo: Move to WikidataStuff.helpers?
+    # @todo: T167661 Move to WikidataStuff.helpers?
     @staticmethod
     def convert_language_dict_to_json(data, typ):
         """

--- a/WFD/WFDBase.py
+++ b/WFD/WFDBase.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Base class on which to build WFD import bots."""
 from __future__ import unicode_literals
-from builtins import dict
+from builtins import dict, open
 import requests
 import xmltodict
 import datetime
@@ -54,7 +54,8 @@ class UnexpectedValueError(pywikibot.Error):
 class WfdBot(object):
     """Base bot to enrich Wikidata with info from WFD."""
 
-    def __init__(self, mappings, year, new, cutoff, edit_summary):
+    def __init__(self, mappings, year, new, cutoff, edit_summary,
+                 preview_file=None):
         """
         Initialise the WfdBot.
 
@@ -65,6 +66,8 @@ class WfdBot(object):
             being interpreted as all.
         :param edit_summary: string to append to all automatically generated
             edit summaries
+        :param preview_file: run in demo mode (create previews rather than
+            live edits) and output the result to this file.
         """
         self.repo = pywikibot.Site().data_repository()
         self.wd = WdS(self.repo, edit_summary)
@@ -72,6 +75,12 @@ class WfdBot(object):
         self.cutoff = cutoff
         self.mappings = mappings
         self.year = year
+        self.preview_file = preview_file
+        if preview_file:
+            self.demo = True
+        else:
+            self.demo = False
+        self.preview_data = []
 
         # known (lower case) non-names
         self.bad_names = ('not applicable', )
@@ -252,6 +261,14 @@ class WfdBot(object):
             return self.wd.make_new_item(item_data, summary)
         except pywikibot.data.api.APIError as e:
             raise pywikibot.Error('Error during item creation: {:s}'.format(e))
+
+    def output_previews(self):
+        """Output any PreviewItems to the preview_file."""
+        with open(self.preview_file, 'w', encoding='utf-8') as f:
+            for preview in self.preview_data:
+                f.write(preview.make_preview_page())
+                f.write('--------------\n\n')
+        pywikibot.output('Created "{}" for previews'.format(self.preview_file))
 
     @staticmethod
     def load_xml_url_data(url, key=None):

--- a/WFD/mappings.json
+++ b/WFD/mappings.json
@@ -14,7 +14,7 @@
         }
     },
     "dataset": {
-        "@meta": "The item corresponding to the country wfd dataset for that year",
+        "@meta": "The item corresponding to the country WFD dataset for that year",
         "2016": {
             "FI": "Q29380097",
             "SE": "Q29563137"

--- a/WFD/mappings.json
+++ b/WFD/mappings.json
@@ -59,7 +59,9 @@
         "SALI": "Q2002254",
         "TEMP": "Q2914309",
         "NOTA": "novalue",
-        "OTHE": "somevalue"
+        "NOSI": "novalue",
+        "OTHE": "somevalue",
+        "UNKN": "somevalue"
     },
     "swEcologicalStatusOrPotentialValue": {
         "@meta": "https://www.wikidata.org/wiki/User:AndreCostaWMSE-bot/WFD/swEcologicalStatusOrPotentialValue",

--- a/WFD/mappings.json
+++ b/WFD/mappings.json
@@ -57,7 +57,9 @@
         "NUTR": "Q12203192",
         "ORGA": "Q28854984",
         "SALI": "Q2002254",
-        "TEMP": "Q2914309"
+        "TEMP": "Q2914309",
+        "NOTA": "novalue",
+        "OTHE": "somevalue"
     },
     "swEcologicalStatusOrPotentialValue": {
         "@meta": "https://www.wikidata.org/wiki/User:AndreCostaWMSE-bot/WFD/swEcologicalStatusOrPotentialValue",

--- a/WFD/swb_import.py
+++ b/WFD/swb_import.py
@@ -80,7 +80,7 @@ class SwbBot(WfdBot):
         """
         Set and validate values shared by every SWB in the dataset.
 
-        :param data: SWB component of thexml data
+        :param data: SWB component of the xml data
         """
         super(SwbBot, self).set_common_values(data)
         try:
@@ -97,9 +97,9 @@ class SwbBot(WfdBot):
         """
         Handle all the surface water bodies in a single RBD.
 
-        Only increments counter when an swb is updated.
+        Only increments counter when an SWB is updated.
 
-        :param data: list of all the swb:s in the RBD
+        :param data: list of all the SWBs in the RBD or a single SWB.
         """
         data = helpers.listify(data)
         count = 0
@@ -118,10 +118,10 @@ class SwbBot(WfdBot):
     # @todo: T167662
     def process_single_swb(self, data, item):
         """
-        Process a swb (whether item exists or not).
+        Process a SWB (whether item exists or not).
 
-        :param data: dict of data for a single swb
-        :param item: Wikidata item associated with a swb, or None if one
+        :param data: dict of data for a single SWB
+        :param item: Wikidata item associated with a SWB, or None if one
             should be created.
         """
         if not self.demo:
@@ -149,7 +149,7 @@ class SwbBot(WfdBot):
         surfaceWaterBodyName always gives the English name but may also be
         set to 'not applicable' (per p.33 of the WFD specifications).
 
-        :param data: dict of data for a single swb
+        :param data: dict of data for a single SWB
         :return: label dict
         """
         labels = {}
@@ -160,9 +160,9 @@ class SwbBot(WfdBot):
 
     def create_new_swb_item(self, data):
         """
-        Create a new swb item with some basic info and return it.
+        Create a new SWB item with some basic info and return it.
 
-        :param data: dict of data for a single swb
+        :param data: dict of data for a single SWB
         :return: pywikibot.ItemPage
         """
         labels = self.make_labels(data)
@@ -176,7 +176,7 @@ class SwbBot(WfdBot):
         """
         Construct potential claims for an entry.
 
-        :param data: dict of data for a single swb
+        :param data: dict of data for a single SWB
         """
         protoclaims = dict()
 
@@ -219,7 +219,7 @@ class SwbBot(WfdBot):
                  of time point?
                * In both cases the reference can still be added.
 
-        :param data: dict of data for a single swb
+        :param data: dict of data for a single SWB
         :return: [Statement]
         """
         claims = []
@@ -254,7 +254,7 @@ class SwbBot(WfdBot):
         Sets the 'somevalue' statement if the status is "Unknown".
         Skips if the value is "Not applicable".
 
-        :param data: dict of data for a single swb
+        :param data: dict of data for a single SWB
         :return: Statement
         """
         claim = None
@@ -335,7 +335,7 @@ def validate_indata(data, mappings):
     """
     # validate mapping of each <surfaceWaterBodyCategory> and
     # <swSignificantImpactType>
-    pywikibot.output('Target file containes {} entries, validating...'.format(
+    pywikibot.output('Target file contains {} entries, validating...'.format(
         len(data.get('SurfaceWaterBody'))))
     swb_cats = set()
     impacts = set()

--- a/WFD/swb_import.py
+++ b/WFD/swb_import.py
@@ -80,7 +80,7 @@ class SwbBot(WfdBot):
         """
         Set and validate values shared by every SWB in the dataset.
 
-        :param data: dict of all the SWB:s in the RBD
+        :param data: SWB component of thexml data
         """
         super(SwbBot, self).set_common_values(data)
         try:
@@ -99,8 +99,9 @@ class SwbBot(WfdBot):
 
         Only increments counter when an swb is updated.
 
-        :param data: dict of all the swb:s in the RBD
+        :param data: list of all the swb:s in the RBD
         """
+        data = helpers.listify(data)
         count = 0
         for entry_data in data:
             if self.cutoff and count >= self.cutoff:
@@ -279,6 +280,7 @@ class SwbBot(WfdBot):
     # @todo: unify arg_handling by breaking this out into
     #        options = WfdBot.handle_args(args) which returns a dict.
     #        also move parameter_help.
+    #        separate mappings_file and actual mappings
     @staticmethod
     def main(*args):
         """Command line entry point."""

--- a/WFD/swb_import.py
+++ b/WFD/swb_import.py
@@ -115,6 +115,7 @@ class SwbBot(WfdBot):
                 self.process_single_swb(entry_data, item)
                 count += 1
 
+    # @todo: T167662
     def process_single_swb(self, data, item):
         """
         Process a swb (whether item exists or not).
@@ -221,7 +222,6 @@ class SwbBot(WfdBot):
         :param data: dict of data for a single swb
         :return: [Statement]
         """
-        # @todo: Support for UNKN, OTHE (somevalue) + NOTA, NOSI (novalue)
         claims = []
         impacts = helpers.listify(data.get('swSignificantImpactType'))
         for impact in impacts:
@@ -273,14 +273,11 @@ class SwbBot(WfdBot):
 
         if claim:
             claim.addQualifier(WdS.Qualifier('P585', self.year))
-            # @todo: handle measurement years https://www.wikidata.org/wiki/Wikidata:Project_chat#Date_qualifiers  # noqa E501
+            # @todo: T167660 for measurement years as qualifier
 
         return claim
 
-    # @todo: unify arg_handling by breaking this out into
-    #        options = WfdBot.handle_args(args) which returns a dict.
-    #        also move parameter_help.
-    #        separate mappings_file and actual mappings
+    # @todo: T167658
     @staticmethod
     def main(*args):
         """Command line entry point."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 xmltodict
 requests
 git+https://github.com/wikimedia/pywikibot-core.git
-git+https://github.com/lokal-profil/wikidata-stuff.git@0.3.3
+git+https://github.com/lokal-profil/wikidata-stuff.git@0.3.4

--- a/tests/test_preview_item.py
+++ b/tests/test_preview_item.py
@@ -1,0 +1,696 @@
+# -*- coding: utf-8  -*-
+"""Unit tests for PreviewItem."""
+from __future__ import unicode_literals
+
+import unittest
+from mock import mock
+
+import pywikibot
+
+from WFD.PreviewItem import PreviewItem
+from wikidataStuff.WikidataStuff import WikidataStuff as WdS
+
+
+class BasicFormatMocker(unittest.TestCase):
+
+    """Patch some basic formatters and provide a repo."""
+
+    def setUp(self):
+        self.repo = pywikibot.Site('test', 'wikidata')
+
+        # patch bold
+        def bold_side_effect(val):
+            return 'bold_{}'.format(val)
+
+        bold_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.make_text_bold')
+        self.mock_bold = bold_patcher.start()
+        self.mock_bold.side_effect = bold_side_effect
+
+        # patch italics
+        def italics_side_effect(val):
+            return 'italics_{}'.format(val)
+
+        italics_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.make_text_italics')
+        self.mock_italics = italics_patcher.start()
+        self.mock_italics.side_effect = italics_side_effect
+
+        self.addCleanup(bold_patcher.stop)
+        self.addCleanup(italics_patcher.stop)
+
+        # patch wikidata_template
+        wd_template_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.make_wikidata_template')
+        self.mock_wd_template = wd_template_patcher.start()
+        self.mock_wd_template.side_effect = ['wd_template_{}'.format(i)
+                                             for i in range(1, 5)]
+        self.addCleanup(wd_template_patcher.stop)
+
+
+class TestPreviewItemBase(BasicFormatMocker):
+
+    """Shared setup for all instance method tests."""
+
+    def setUp(self):
+        super(TestPreviewItemBase, self).setUp()
+        self.preview_item = PreviewItem(
+            labels={}, descriptions={}, protoclaims={}, item=None, ref=None)
+
+
+class TestMakeWikidataTemplate(unittest.TestCase):
+
+    """Test the make_wikidata_template method."""
+
+    def setUp(self):
+        self.repo = pywikibot.Site('test', 'wikidata')
+
+    def test_make_wikidata_template_empty(self):
+        with self.assertRaises(ValueError) as cm:
+            PreviewItem.make_wikidata_template('')
+        self.assertEqual(
+            str(cm.exception),
+            'Sorry only items and properties are supported, not whatever '
+            '"" is.'
+        )
+
+    def test_make_wikidata_template_none(self):
+        with self.assertRaises(ValueError) as cm:
+            PreviewItem.make_wikidata_template(None)
+        self.assertEqual(
+            str(cm.exception),
+            'Sorry only items and properties are supported, not whatever '
+            '"None" is.'
+        )
+
+    def test_make_wikidata_template_qid(self):
+        expected = '{{Q|Q123}}'
+        self.assertEqual(
+            PreviewItem.make_wikidata_template('Q123'),
+            expected
+        )
+
+    def test_make_wikidata_template_pid(self):
+        expected = '{{P|P123}}'
+        self.assertEqual(
+            PreviewItem.make_wikidata_template('P123'),
+            expected
+        )
+
+    def test_make_wikidata_template_item_page(self):
+        expected = '{{Q|Q321}}'
+        item = pywikibot.ItemPage(self.repo, 'Q321')
+        self.assertEqual(
+            PreviewItem.make_wikidata_template(item),
+            expected
+        )
+
+    def test_make_wikidata_template_property_page(self):
+        expected = '{{P|P321}}'
+        prop = pywikibot.PropertyPage(self.repo, 'P321')
+        self.assertEqual(
+            PreviewItem.make_wikidata_template(prop),
+            expected
+        )
+
+    def test_make_wikidata_template_bad_id_fail(self):
+        with self.assertRaises(ValueError) as cm:
+            PreviewItem.make_wikidata_template('dummy')
+        self.assertEqual(
+            str(cm.exception),
+            'Sorry only items and properties are supported, not whatever '
+            '"dummy" is.'
+        )
+
+    def test_make_wikidata_template_special_novalue(self):
+        expected = "{{Q'|no value}}"
+        self.assertEqual(
+            PreviewItem.make_wikidata_template('novalue', special=True),
+            expected
+        )
+
+    def test_make_wikidata_template_special_somevalue(self):
+        expected = "{{Q'|some value}}"
+        self.assertEqual(
+            PreviewItem.make_wikidata_template('somevalue', special=True),
+            expected
+        )
+
+    def test_make_wikidata_template_special_fail(self):
+        with self.assertRaises(ValueError) as cm:
+            PreviewItem.make_wikidata_template('dummy', special=True)
+        self.assertEqual(
+            str(cm.exception),
+            'Sorry but "dummy" is not a recognized special value/snacktype.'
+        )
+
+
+class TestFormatItem(TestPreviewItemBase):
+
+    """Test the format_item method."""
+
+    def test_format_item_none(self):
+        self.preview_item.item = None
+        self.assertEqual(
+            self.preview_item.format_item(),
+            'New item created'
+        )
+
+    def test_format_item_with_item(self):
+        self.preview_item.item = 'anything'
+        self.preview_item.format_item()
+        self.mock_wd_template.assert_called_once_with('anything')
+
+
+class TestFormatDescriptions(TestPreviewItemBase):
+
+    """Test the format_descriptions method."""
+
+    def test_format_descriptions_empty(self):
+        self.preview_item.desc_dict = {}
+        self.assertEqual(self.preview_item.format_descriptions(), '')
+
+    def test_make_wikidata_template_with_data(self):
+        self.preview_item.desc_dict = {
+            'en': 'en_desc',
+            'sv': 'sv_desc'
+        }
+        expected = (
+            '* bold_en: en_desc\n'
+            '* bold_sv: sv_desc\n'
+        )
+        self.assertEqual(self.preview_item.format_descriptions(), expected)
+        self.mock_bold.assert_has_calls([mock.call('en'), mock.call('sv')])
+
+
+class TestFormatLabels(TestPreviewItemBase):
+
+    """Test the format_labels method."""
+
+    def test_format_labels_empty(self):
+        self.preview_item.labels_dict = {}
+        self.assertEqual(self.preview_item.format_labels(), '')
+
+    def test_format_labels_with_multiple_langs(self):
+        self.preview_item.labels_dict = {
+            'en': ['en_label'],
+            'sv': ['sv_label']
+        }
+        expected = (
+            '* bold_en: italics_en_label\n'
+            '* bold_sv: italics_sv_label\n'
+        )
+        self.assertEqual(self.preview_item.format_labels(), expected)
+        self.mock_bold.assert_has_calls([mock.call('en'), mock.call('sv')])
+
+    def test_format_labels_with_multiple_names(self):
+        self.preview_item.labels_dict = {
+            'en': ['en_label', 'en_alias_1', 'en_alias_2']
+        }
+        expected = (
+            '* bold_en: italics_en_label | en_alias_1 | en_alias_2\n'
+        )
+        self.assertEqual(self.preview_item.format_labels(), expected)
+        self.mock_bold.assert_called_once_with('en')
+        self.mock_italics.assert_called_once_with('en_label')
+
+
+class TestFormatItis(BasicFormatMocker):
+
+    """Test the format_itis method."""
+
+    def setUp(self):
+        super(TestFormatItis, self).setUp()
+        timestring_patcher = mock.patch(
+            'WFD.PreviewItem.pywikibot.WbTime.toTimestr')
+        self.mock_format_timestring = timestring_patcher.start()
+        self.mock_format_timestring.return_value = 'formatted_WbTime'
+        self.addCleanup(timestring_patcher.stop)
+
+    def test_format_itis_None(self):
+        itis = None
+        expected = 'None'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_item_page(self):
+        itis = pywikibot.ItemPage(self.repo, 'Q123')
+        expected = 'wd_template_1'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_called_once_with(itis)
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_quantity(self):
+        itis = pywikibot.WbQuantity(123)
+        expected = '123'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_quantity_unit(self):
+        unit = pywikibot.ItemPage(self.repo, 'Q123')
+        itis = pywikibot.WbQuantity(123, unit=unit)
+        expected = '123 wd_template_1'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_called_once_with(unit)
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_time(self):
+        itis = pywikibot.WbTime(year=1999)
+        expected = 'formatted_WbTime'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_timestring.assert_called_once()
+
+    def test_format_itis_other(self):
+        itis = [1, 2, 3]
+        expected = '[1, 2, 3]'
+        self.assertEqual(PreviewItem.format_itis(itis), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_special(self):
+        itis = 'dummy'
+        expected = 'wd_template_1'
+        self.assertEqual(
+            PreviewItem.format_itis(itis, special=True),
+            expected
+        )
+        self.mock_wd_template.assert_called_once_with(itis, special=True)
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_statement_item(self):
+        item = pywikibot.ItemPage(self.repo, 'Q123')
+        itis = WdS.Statement(item)
+        expected = 'wd_template_1'
+        self.assertEqual(
+            PreviewItem.format_itis(itis),
+            expected
+        )
+        self.mock_wd_template.assert_called_once_with(item)
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_statement_other(self):
+        itis = WdS.Statement('dummy')
+        expected = 'dummy'
+        self.assertEqual(
+            PreviewItem.format_itis(itis),
+            expected
+        )
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_timestring.assert_not_called()
+
+    def test_format_itis_statement_detect_special(self):
+        itis = WdS.Statement('novalue', special=True)
+        expected = 'wd_template_1'
+        self.assertEqual(
+            PreviewItem.format_itis(itis),
+            expected
+        )
+        self.mock_wd_template.assert_called_once_with('novalue', special=True)
+        self.mock_format_timestring.assert_not_called()
+
+
+class TestFormatClaim(BasicFormatMocker):
+
+    """Test the format_claim method."""
+
+    def setUp(self):
+        super(TestFormatClaim, self).setUp()
+        itis_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_itis')
+        self.mock_format_itis = itis_patcher.start()
+        self.mock_format_itis.return_value = 'formatted_itis'
+        self.addCleanup(itis_patcher.stop)
+
+    def test_format_claim_basic(self):
+        claim = pywikibot.Claim(self.repo, 'P123')
+        claim.setTarget('1')
+        expected = 'wd_template_1: formatted_itis'
+        self.assertEqual(PreviewItem.format_claim(claim), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with('1', False)
+
+    def test_format_claim_special(self):
+        claim = pywikibot.Claim(self.repo, 'P123')
+        claim.setSnakType('novalue')
+        expected = 'wd_template_1: formatted_itis'
+        self.assertEqual(PreviewItem.format_claim(claim), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with('novalue', True)
+
+
+class TestFormatReference(BasicFormatMocker):
+
+    """Test the format_reference method."""
+
+    def setUp(self):
+        super(TestFormatReference, self).setUp()
+        claim_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_claim')
+        self.mock_format_claim = claim_patcher.start()
+        self.mock_format_claim.side_effect = ['formatted_claim_{}'.format(i)
+                                              for i in range(1, 5)]
+        self.addCleanup(claim_patcher.stop)
+
+        self.claim_1 = pywikibot.Claim(self.repo, 'P123')
+        self.claim_1.setTarget('1')
+        self.claim_2 = pywikibot.Claim(self.repo, 'P123')
+        self.claim_1.setTarget('2')
+        self.claim_3 = pywikibot.Claim(self.repo, 'P123')
+        self.claim_1.setTarget('3')
+        self.claim_4 = pywikibot.Claim(self.repo, 'P123')
+        self.claim_1.setTarget('4')
+
+    def test_format_reference_basic(self):
+        ref = WdS.Reference(
+            source_test=[self.claim_1, self.claim_2],
+            source_notest=[self.claim_3, self.claim_4]
+        )
+        expected = (
+            ':italics_tested:\n'
+            ':*formatted_claim_1\n'
+            ':*formatted_claim_2\n'
+            ':italics_not tested:\n'
+            ':*formatted_claim_3\n'
+            ':*formatted_claim_4\n'
+        )
+        self.assertEqual(PreviewItem.format_reference(ref), expected)
+
+        self.mock_format_claim.assert_has_calls([
+            mock.call(self.claim_1),
+            mock.call(self.claim_2),
+            mock.call(self.claim_3),
+            mock.call(self.claim_4)
+        ])
+        self.mock_italics.assert_has_calls([
+            mock.call('tested'),
+            mock.call('not tested')
+        ])
+
+    def test_format_reference_no_test(self):
+        ref = WdS.Reference(source_notest=self.claim_1)
+        expected = (
+            ':italics_not tested:\n'
+            ':*formatted_claim_1\n'
+        )
+        self.assertEqual(PreviewItem.format_reference(ref), expected)
+
+        self.mock_format_claim.assert_called_once_with(self.claim_1)
+        self.mock_italics.assert_called_once_with('not tested')
+
+    def test_format_reference_no_notest(self):
+        ref = WdS.Reference(source_test=self.claim_1)
+        expected = (
+            ':italics_tested:\n'
+            ':*formatted_claim_1\n'
+        )
+        self.assertEqual(PreviewItem.format_reference(ref), expected)
+
+        self.mock_format_claim.assert_called_once_with(self.claim_1)
+        self.mock_italics.assert_called_once_with('tested')
+
+
+class TestFormatQual(BasicFormatMocker):
+
+    """Test the format_qual method."""
+
+    def setUp(self):
+        super(TestFormatQual, self).setUp()
+        itis_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_itis')
+        self.mock_format_itis = itis_patcher.start()
+        self.mock_format_itis.return_value = 'formatted_itis'
+        self.addCleanup(itis_patcher.stop)
+
+    def test_format_qual_basic(self):
+        qual = WdS.Qualifier('P123', 'val')
+        self.assertEqual(
+            PreviewItem.format_qual(qual), 'wd_template_1: formatted_itis')
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with('val')
+
+
+class TestFormatProtoclaims(TestPreviewItemBase):
+
+    """Test the format_protoclaims method."""
+
+    def setUp(self):
+        super(TestFormatProtoclaims, self).setUp()
+        itis_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_itis')
+        self.mock_format_itis = itis_patcher.start()
+        self.mock_format_itis.side_effect = ['formatted_itis_{}'.format(i)
+                                             for i in range(1, 5)]
+        self.addCleanup(itis_patcher.stop)
+
+        qual_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_qual')
+        self.mock_format_qual = qual_patcher.start()
+        self.mock_format_qual.side_effect = ['formatted_qual_{}'.format(i)
+                                             for i in range(1, 5)]
+        self.addCleanup(qual_patcher.stop)
+
+    def test_format_protoclaims_no_protoclaims(self):
+        self.preview_item.protoclaims = {}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_itis.assert_not_called()
+        self.mock_format_qual.assert_not_called()
+
+    def test_format_protoclaims_no_single_none_claim(self):
+        self.preview_item.protoclaims = {'P123': None}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_not_called()
+        self.mock_format_itis.assert_not_called()
+        self.mock_format_qual.assert_not_called()
+
+    def test_format_protoclaims_single(self):
+        itis = WdS.Statement('dummy')
+        self.preview_item.protoclaims = {'P123': itis}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_1 \n'
+            '|  \n'
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with(itis)
+        self.mock_format_qual.assert_not_called()
+
+    def test_format_protoclaims_single_with_qual(self):
+        itis = WdS.Statement('dummy')
+        qual = WdS.Qualifier('P321', 'qual_dummy')
+        itis._quals.add(qual)
+        self.preview_item.protoclaims = {'P123': itis}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_1 \n'
+            '| formatted_qual_1 \n'
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with(itis)
+        self.mock_format_qual.assert_called_once_with(qual)
+
+    def test_format_protoclaims_single_with_multiple_qual(self):
+        itis = WdS.Statement('dummy')
+        qual_1 = WdS.Qualifier('P321', 'qual_dummy')
+        qual_2 = WdS.Qualifier('P213', 'qual_dummy')
+        itis._quals.add(qual_1)
+        itis._quals.add(qual_2)
+        self.preview_item.protoclaims = {'P123': itis}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_1 \n'
+            '| * formatted_qual_1 \n'
+            '* formatted_qual_2 \n'
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_called_once_with(itis)
+        self.mock_format_qual.assert_has_calls([
+            mock.call(qual_1),
+            mock.call(qual_2)],
+            any_order=True
+        )
+
+    def test_format_protoclaims_multple_same_prop(self):
+        itis_1 = WdS.Statement('foo')
+        itis_2 = WdS.Statement('bar')
+        self.preview_item.protoclaims = {'P123': [itis_1, itis_2]}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_1 \n'
+            '|  \n'
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_2 \n'
+            '|  \n'
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_called_once_with('P123')
+        self.mock_format_itis.assert_has_calls([
+            mock.call(itis_1),
+            mock.call(itis_2)
+        ])
+        self.mock_format_qual.assert_not_called()
+
+    def test_format_protoclaims_multple_different_prop(self):
+        itis_1 = WdS.Statement('foo')
+        itis_2 = WdS.Statement('bar')
+        self.preview_item.protoclaims = {'P123': itis_1, 'P321': itis_2}
+        expected = (
+            "{| class='wikitable'\n"
+            "|-\n"
+            "! Property\n"
+            "! Value\n"
+            "! Qualifiers\n"
+            '|-\n'
+            '| wd_template_1 \n'
+            '| formatted_itis_1 \n'
+            '|  \n'
+            '|-\n'
+            '| wd_template_2 \n'
+            '| formatted_itis_2 \n'
+            '|  \n'
+            "|}"
+        )
+        self.assertEqual(self.preview_item.format_protoclaims(), expected)
+        self.mock_wd_template.assert_has_calls([
+            mock.call('P123'),
+            mock.call('P321')],
+            any_order=True
+        )
+        self.mock_format_itis.assert_has_calls([
+            mock.call(itis_1),
+            mock.call(itis_2)],
+            any_order=True
+        )
+        self.mock_format_qual.assert_not_called()
+
+
+class TestMakePreviewPage(TestPreviewItemBase):
+
+    """Test the make_preview_page method."""
+
+    def setUp(self):
+        super(TestMakePreviewPage, self).setUp()
+        label_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_labels')
+        self.mock_format_label = label_patcher.start()
+        self.mock_format_label.return_value = 'formatted_label'
+        self.addCleanup(label_patcher.stop)
+
+        description_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_descriptions')
+        self.mock_format_description = description_patcher.start()
+        self.mock_format_description.return_value = 'formatted_description'
+        self.addCleanup(description_patcher.stop)
+
+        item_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_item')
+        self.mock_format_item = item_patcher.start()
+        self.mock_format_item.return_value = 'formatted_item'
+        self.addCleanup(item_patcher.stop)
+
+        reference_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_reference')
+        self.mock_format_reference = reference_patcher.start()
+        self.mock_format_reference.return_value = 'formatted_reference'
+        self.addCleanup(reference_patcher.stop)
+
+        protoclaim_patcher = mock.patch(
+            'WFD.PreviewItem.PreviewItem.format_protoclaims')
+        self.mock_format_protoclaim = protoclaim_patcher.start()
+        self.mock_format_protoclaim.return_value = 'formatted_protoclaim'
+        self.addCleanup(protoclaim_patcher.stop)
+
+    def test_make_preview_page_basic(self):
+        self.preview_item.ref = 'refs'
+        expected = (
+            'bold_Labels | Aliases:\nformatted_label\n\n'
+            'bold_Descriptions:\nformatted_description\n\n'
+            'bold_Matching item: formatted_item\n\n'
+            'bold_Reference (same for all claims):\nformatted_reference\n\n'
+            'bold_Claims:\nformatted_protoclaim\n\n'
+        )
+        self.assertEqual(self.preview_item.make_preview_page(), expected)
+        self.mock_bold.assert_has_calls([
+            mock.call('Labels | Aliases'),
+            mock.call('Descriptions'),
+            mock.call('Matching item'),
+            mock.call('Reference (same for all claims)'),
+            mock.call('Claims')
+        ])
+        self.mock_format_label.assert_called_once()
+        self.mock_format_description.assert_called_once()
+        self.mock_format_item.assert_called_once()
+        self.mock_format_reference.assert_called_once_with('refs')
+        self.mock_format_protoclaim.assert_called_once()
+
+    def test_make_preview_page_no_ref(self):
+        self.preview_item.ref = None
+        expected = (
+            'bold_Labels | Aliases:\nformatted_label\n\n'
+            'bold_Descriptions:\nformatted_description\n\n'
+            'bold_Matching item: formatted_item\n\n'
+            'bold_Claims:\nformatted_protoclaim\n\n'
+        )
+        self.assertEqual(self.preview_item.make_preview_page(), expected)
+        self.mock_bold.assert_has_calls([
+            mock.call('Labels | Aliases'),
+            mock.call('Descriptions'),
+            mock.call('Matching item'),
+            mock.call('Claims')
+        ])
+        self.mock_format_label.assert_called_once()
+        self.mock_format_description.assert_called_once()
+        self.mock_format_item.assert_called_once()
+        self.mock_format_reference.assert_not_called()
+        self.mock_format_protoclaim.assert_called_once()

--- a/tests/test_preview_item.py
+++ b/tests/test_preview_item.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import unittest
 from mock import mock
+from collections import OrderedDict
 
 import pywikibot
 
@@ -171,10 +172,12 @@ class TestFormatDescriptions(TestPreviewItemBase):
         self.assertEqual(self.preview_item.format_descriptions(), '')
 
     def test_make_wikidata_template_with_data(self):
-        self.preview_item.desc_dict = {
+        descriptions = {
             'en': 'en_desc',
             'sv': 'sv_desc'
         }
+        self.preview_item.desc_dict = OrderedDict(
+            sorted(descriptions.items(), key=lambda t: t[0]))
         expected = (
             '* bold_en: en_desc\n'
             '* bold_sv: sv_desc\n'
@@ -192,10 +195,12 @@ class TestFormatLabels(TestPreviewItemBase):
         self.assertEqual(self.preview_item.format_labels(), '')
 
     def test_format_labels_with_multiple_langs(self):
-        self.preview_item.labels_dict = {
+        labels = {
             'en': ['en_label'],
             'sv': ['sv_label']
         }
+        self.preview_item.labels_dict = OrderedDict(
+            sorted(labels.items(), key=lambda t: t[0]))
         expected = (
             '* bold_en: italics_en_label\n'
             '* bold_sv: italics_sv_label\n'
@@ -584,7 +589,9 @@ class TestFormatProtoclaims(TestPreviewItemBase):
     def test_format_protoclaims_multple_different_prop(self):
         itis_1 = WdS.Statement('foo')
         itis_2 = WdS.Statement('bar')
-        self.preview_item.protoclaims = {'P123': itis_1, 'P321': itis_2}
+        protoclaims = {'P123': itis_1, 'P321': itis_2}
+        self.preview_item.protoclaims = OrderedDict(
+            sorted(protoclaims.items(), key=lambda t: t[0]))
         expected = (
             "{| class='wikitable'\n"
             "|-\n"

--- a/tests/test_preview_item.py
+++ b/tests/test_preview_item.py
@@ -227,7 +227,7 @@ class TestFormatItis(BasicFormatMocker):
         self.mock_format_timestring.return_value = 'formatted_WbTime'
         self.addCleanup(timestring_patcher.stop)
 
-    def test_format_itis_None(self):
+    def test_format_itis_none(self):
         itis = None
         expected = 'None'
         self.assertEqual(PreviewItem.format_itis(itis), expected)
@@ -242,7 +242,7 @@ class TestFormatItis(BasicFormatMocker):
         self.mock_format_timestring.assert_not_called()
 
     def test_format_itis_quantity(self):
-        itis = pywikibot.WbQuantity(123)
+        itis = pywikibot.WbQuantity(123, site=self.repo)
         expected = '123'
         self.assertEqual(PreviewItem.format_itis(itis), expected)
         self.mock_wd_template.assert_not_called()
@@ -250,7 +250,7 @@ class TestFormatItis(BasicFormatMocker):
 
     def test_format_itis_quantity_unit(self):
         unit = pywikibot.ItemPage(self.repo, 'Q123')
-        itis = pywikibot.WbQuantity(123, unit=unit)
+        itis = pywikibot.WbQuantity(123, unit=unit, site=self.repo)
         expected = '123 wd_template_1'
         self.assertEqual(PreviewItem.format_itis(itis), expected)
         self.mock_wd_template.assert_called_once_with(unit)

--- a/tests/test_preview_item.py
+++ b/tests/test_preview_item.py
@@ -141,7 +141,7 @@ class TestMakeWikidataTemplate(unittest.TestCase):
             PreviewItem.make_wikidata_template('dummy', special=True)
         self.assertEqual(
             str(cm.exception),
-            'Sorry but "dummy" is not a recognized special value/snacktype.'
+            'Sorry but "dummy" is not a recognized special value/snaktype.'
         )
 
 
@@ -153,7 +153,7 @@ class TestFormatItem(TestPreviewItemBase):
         self.preview_item.item = None
         self.assertEqual(
             self.preview_item.format_item(),
-            'New item created'
+            '–'
         )
 
     def test_format_item_with_item(self):

--- a/tests/test_preview_item.py
+++ b/tests/test_preview_item.py
@@ -591,7 +591,7 @@ class TestFormatProtoclaims(TestPreviewItemBase):
         itis_2 = WdS.Statement('bar')
         protoclaims = {'P123': itis_1, 'P321': itis_2}
         self.preview_item.protoclaims = OrderedDict(
-            sorted(protoclaims.items(), key=lambda t: t[0]))
+            sorted(protoclaims.items(), key=lambda t: int(t[0][1:])))
         expected = (
             "{| class='wikitable'\n"
             "|-\n"


### PR DESCRIPTION
Adds the `-preview_file` argument which, if provided, outputs a
preview of the changes to that file rather than making the actual
changes. Can be run together with the `-simulate` argument for
paranoid users.

Also:
* Fix broken import in RBD
* Fix `novalue`/`somevalue` handling in impact type
* Fix single value in impact type
* Implement `set_common_value`s fully for RBD
* Merge `process_all_rbd` and `process_country_rbd` in RBD
* Fix minor bugs/typos

Task: [T166673](https://phabricator.wikimedia.org/T166673)