### PR TITLE
Support harvesting of gml files and adding local names

### DIFF
--- a/WFD/RBD.py
+++ b/WFD/RBD.py
@@ -32,10 +32,11 @@ class RbdBot(WfdBot):
     """Bot to enrich/create info on Wikidata for RBD objects."""
 
     def __init__(self, mappings, year, new=False, cutoff=None,
-                 preview_file=None):
+                 gml_data=None, preview_file=None):
         """Initialise the RbdBot."""
         super(RbdBot, self).__init__(mappings, year, new, cutoff,
-                                     EDIT_SUMMARY, preview_file=preview_file)
+                                     EDIT_SUMMARY, gml_data=gml_data,
+                                     preview_file=preview_file)
 
         self.rbd_q = 'Q132017'
         self.eu_rbd_p = 'P2965'
@@ -170,6 +171,8 @@ class RbdBot(WfdBot):
         if with_alias:
             labels['en'] = labels.get('en') or []
             labels['en'].append(entry_data.get('euRBDCode'))
+
+        self.add_local_name(labels, entry_data.get('euRBDCode'))
         return labels
 
     def make_descriptions(self, entry_data):
@@ -240,13 +243,17 @@ class RbdBot(WfdBot):
     def main(*args):
         """Command line entry point."""
         options = WfdBot.handle_args(args)
+        gml_data = None
 
         # load mappings and initialise RBD object
         mappings = helpers.load_json_file(
             options['mappings'], options['force_path'])
         data = WfdBot.load_data(options['in_file'], key='RBDSUCA')
+        if options['gml_file']:
+            gml_data = WfdBot.load_gml_data(
+                options['gml_file'], 'wfdgml:RiverBasinDistrict')
         rbd = RbdBot(mappings, options['year'], new=options['new'],
-                     cutoff=options['cutoff'],
+                     cutoff=options['cutoff'], gml_data=gml_data,
                      preview_file=options['preview_file'])
         rbd.set_common_values(data)
 

--- a/WFD/mappings.json
+++ b/WFD/mappings.json
@@ -24,6 +24,10 @@
         "fin": "fi",
         "swe": "sv"
     },
+    "units": {
+        "@meta": "gml unit abbreviations mapped to helpers.get_unit_q() abbreviations",
+        "km2": "km²"
+    },
     "CompetentAuthority": {
         "SE1": "Q25386488",
         "SE2": "Q26236748",

--- a/WFD/swb_import.py
+++ b/WFD/swb_import.py
@@ -35,7 +35,7 @@ class SwbBot(WfdBot):
     """Bot to enrich/create info on Wikidata for SWB objects."""
 
     def __init__(self, mappings, year, new=False, cutoff=None,
-                 preview_file=None):
+                 gml_data=None, preview_file=None):
         """
         Initialise the SwbBot.
 
@@ -46,7 +46,8 @@ class SwbBot(WfdBot):
             being interpreted as all.
         """
         super(SwbBot, self).__init__(mappings, year, new, cutoff,
-                                     EDIT_SUMMARY, preview_file=preview_file)
+                                     EDIT_SUMMARY, gml_data=gml_data,
+                                     preview_file=preview_file)
 
         self.eu_swb_p = 'P2856'  # eu_cd
         self.eu_rbd_p = 'P2965'  # euRBDCode
@@ -149,6 +150,8 @@ class SwbBot(WfdBot):
         name = data.get('surfaceWaterBodyName')
         if name and name.lower() not in self.bad_names:
             labels['en'] = name
+
+        self.add_local_name(labels, data.get('euSurfaceWaterBodyCode'))
         return labels
 
     def create_new_swb_item(self, data):
@@ -275,16 +278,20 @@ class SwbBot(WfdBot):
     def main(*args):
         """Command line entry point."""
         options = WfdBot.handle_args(args)
+        gml_data = None
 
         # load and validate data and mappings
         mappings = helpers.load_json_file(
             options['mappings'], options['force_path'])
         data = WfdBot.load_data(options['in_file'], key='SWB')
+        if options['gml_file']:
+            gml_data = WfdBot.load_gml_data(
+                options['gml_file'], 'wfdgml:SurfaceWaterBody')
         validate_indata(data, mappings)
 
         # initialise SwbBot object
         bot = SwbBot(mappings, options['year'], new=options['new'],
-                     cutoff=options['cutoff'],
+                     cutoff=options['cutoff'], gml_data=gml_data,
                      preview_file=options['preview_file'])
         bot.set_common_values(data)
 


### PR DESCRIPTION
This makes it possible to also harvest the gml files that goes with
both RBD and SWB data. The gml files contain labels in the local
language, and for SWBs also areas. The data is harvested,
reformatted, validated and a gml specific reference is created.

This commit also adds the local language label.

Task: [T166883](https://phabricator.wikimedia.org/T166883)